### PR TITLE
Allow user to define scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ debug = true
 product = false
 log.file = /var/log/console.log
 log.conf.file = /var/log/config
-debug == true
-dasdasbjdnw:
 count = 452
 port = 80
 ```
@@ -39,7 +37,6 @@ log.conf.file -> string
 ; log.conf.template -> string
 count -> number
 port -> string
-count = number
 ```
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ port = 80
 
 #### scheme format
 
-Scheme file format is as same as `sysctl.conf` except for the separator (use `->` not `=`)
+- Scheme file format is as same as `sysctl.conf` except for the separator (use `->` not `=`)
+- You can define`string`, `number`, `boolean` or `undefined` type now.
 
 **scheme file example**
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,70 @@
+# Explanation
+
+### Overview
+
+This package can parse `sysctl.conf` file into object.
+If you want to define scheme, pass it as a second parameter.
+
+**`sysctl.conf` file example**
+
+```example.txt
+endpoint = localhost:3000
+ test = testVal
+# test2 = t2va
+; test3 = t3va
+debug = true
+product = false
+log.file = /var/log/console.log
+log.conf.file = /var/log/config
+debug == true
+dasdasbjdnw:
+count = 452
+port = 80
+```
+
+#### scheme format
+
+Scheme file format is as same as `sysctl.conf` except for the separator (use `->` not `=`)
+
+**scheme file example**
+
+```scheme.txt
+endpoint -> string
+  debug -> boolean
+# product -> boolean
+product ->  string
+log.file -> number
+log.conf.file -> string
+; log.conf.template -> string
+count -> number
+port -> string
+count = number
+```
+
 # Installation
 
 run `npm install <PATH_TO_THIS_REPOSITORY>` to add this package.
 
 # Usage Example
 
+- without scheme
+
 ```js
 const sysctlParser = require("sysctl-parser");
-const obj = sysctlParser(`endpoint = localhost:3000
+const sysctlFileContents = `endpoint = localhost:3000
  test = testVal
 # test2 = t2va
 ; test3 = t3va
 debug = true
+product = false
 log.file = /var/log/console.log
+log.conf.file = /var/log/config
 debug == true
 dasdasbjdnw:
-count = 452`);
+count = 452
+port = 80`;
+
+const obj = sysctlParser(sysctlFileContents);
 
 /* 
   obj = 
@@ -22,7 +72,50 @@ count = 452`);
     endpoint: 'localhost:3000',
     test: 'testVal',
     debug: true,
-    log: { file: '/var/log/console.log' },
+    product: false,
+    log: { file: '/var/log/console.log', conf: { file: '/var/log/config' } },
+    count: 452,
+    port: 80
+  }
+*/
+```
+
+- with scheme
+
+```js
+const sysctlParser = require("sysctl-parser");
+const sysctlFileContents = `endpoint = localhost:3000
+ test = testVal
+# test2 = t2va
+; test3 = t3va
+debug = true
+product = false
+log.file = /var/log/console.log
+log.conf.file = /var/log/config
+debug == true
+dasdasbjdnw:
+count = 452
+port = 80`;
+
+const schemeFileContents = `endpoint -> string
+  debug -> boolean
+# product -> boolean
+product ->  string
+log.file -> number
+log.conf.file -> string
+; log.conf.template -> string
+count -> number
+port -> string
+count = number`;
+
+const obj = sysctlParser(sysctlFileContents, schemeFileContents);
+
+/* 
+  obj = 
+  {
+    endpoint: 'localhost:3000',
+    debug: true,
+    log: { conf: { file: '/var/log/config' } },
     count: 452
   }
 */

--- a/data/example.txt
+++ b/data/example.txt
@@ -3,7 +3,10 @@ endpoint = localhost:3000
 # test2 = t2va
 ; test3 = t3va
 debug = true
+product = false
 log.file = /var/log/console.log
+log.conf.file = /var/log/config
 debug == true
 dasdasbjdnw:
 count = 452
+port = 80

--- a/data/scheme.txt
+++ b/data/scheme.txt
@@ -1,0 +1,10 @@
+endpoint -> string
+  debug -> boolean
+# product -> boolean
+product ->  string
+log.file -> number
+log.conf.file -> string
+; log.conf.template -> string
+count -> number
+port -> string
+count = number

--- a/src/example.js
+++ b/src/example.js
@@ -1,5 +1,5 @@
 const fs = require("fs").promises;
-const { parseFileContents } = require("./utils/files");
+const { parseFileContents, parseSchemeFileContents } = require("./utils/files");
 
 const example = async () => {
   // sample data
@@ -8,12 +8,15 @@ const example = async () => {
   const fileName = "./data/example.txt";
   const fileContents = await fs.readFile(fileName, "utf8");
 
-  console.log("============");
-  console.log(fileContents);
-  console.log("============");
+  const schemeFileName = "./data/scheme.txt";
+  const schemeFileContents = await fs.readFile(schemeFileName, "utf8");
 
-  const result = parseFileContents(fileContents);
-  console.log("result : ", result);
+  const resultWithoutScheme = parseFileContents(fileContents);
+  console.log("-----------------------");
+  console.log("resultWithoutScheme : ", resultWithoutScheme);
+  const resultWithScheme = parseFileContents(fileContents, schemeFileContents);
+  console.log("-----------------------");
+  console.log(" resultWithScheme: ", resultWithScheme);
 };
 
 example();

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -3,20 +3,57 @@ const _set = require("lodash/set");
 const { isValidLine } = require("./handleLine");
 const { valueWithType } = require("./types");
 
-const readFileContents = (fileContents) => {
+const readFileContents = (fileContents, separator = "=") => {
   return fileContents
     .split(/\n/)
-    .filter((line) => isValidLine(line))
+    .filter((line) => isValidLine(line, separator))
     .map((line) => line.replace(/^\s+|\s+$/g, "")); // triming new line characters
 };
 
-const parseFileContents = (fileContents) => {
-  const lines = readFileContents(fileContents);
-  return lines.reduce((oldObj, line) => {
+const parseSchemeFileContents = (schemeFileContents) => {
+  const schemeFileLines = readFileContents(schemeFileContents, "->");
+  return schemeFileLines.reduce((oldObj, line) => {
+    const [key, value] = line.split("->").map((e) => e.trim());
+    const typeDefinedValue = valueWithType(value);
+    return Object.assign(oldObj, { [key]: value });
+  }, {});
+};
+
+const parseSysctlFileContentsWithScheme = (
+  confFileContents,
+  schemeFileContents
+) => {
+  const schemeFileObj = parseSchemeFileContents(schemeFileContents);
+  const confFileLines = readFileContents(confFileContents, "=");
+
+  return confFileLines.reduce((oldObj, line) => {
+    const [key, value] = line.split("=").map((e) => e.trim());
+    const typeDefinedValue = valueWithType(value);
+    const schemeDefinedType = schemeFileObj[key];
+    return typeof typeDefinedValue === schemeDefinedType
+      ? _set(oldObj, key, typeDefinedValue)
+      : oldObj;
+  }, {});
+};
+
+const parseSysctlFileContentsWithoutScheme = (confFileContents) => {
+  const confFileLines = readFileContents(confFileContents, "=");
+  return confFileLines.reduce((oldObj, line) => {
     const [key, value] = line.split("=").map((e) => e.trim());
     const typeDefinedValue = valueWithType(value);
     return _set(oldObj, key, typeDefinedValue);
   }, {});
 };
 
-module.exports = { parseFileContents };
+const parseFileContents = (confFileContents, schemeFileContents) => {
+  return schemeFileContents
+    ? parseSysctlFileContentsWithScheme(confFileContents, schemeFileContents)
+    : parseSysctlFileContentsWithoutScheme(confFileContents);
+};
+
+module.exports = {
+  readFileContents,
+  parseFileContents,
+  parseSchemeFileContents,
+  parseSysctlFileContentsWithScheme,
+};

--- a/src/utils/files.test.js
+++ b/src/utils/files.test.js
@@ -1,7 +1,11 @@
 const fs = require("fs").promises;
-const { parseFileContents } = require("./files");
+const {
+  parseFileContents,
+  parseSysctlFileContentsWithScheme,
+} = require("./files");
 
 const dummyDataPath = "./data/example.txt";
+const dummySchemePath = "./data/scheme.txt";
 
 test("dummy data will be parsed collectly", async () => {
   const dummyData = await fs.readFile(dummyDataPath, "utf8");
@@ -9,7 +13,54 @@ test("dummy data will be parsed collectly", async () => {
     endpoint: "localhost:3000",
     test: "testVal",
     debug: true,
-    log: { file: "/var/log/console.log" },
+    product: false,
+    log: { file: "/var/log/console.log", conf: { file: "/var/log/config" } },
+    count: 452,
+    port: 80,
+  });
+});
+
+test("dummy data line should follow scheme", async () => {
+  // follows scheme(string)
+  expect(
+    parseSysctlFileContentsWithScheme(
+      "endpoint = localhost:3000",
+      "endpoint -> string"
+    )
+  ).toEqual({ endpoint: "localhost:3000" });
+  // follows scheme(boolean)
+  expect(
+    parseSysctlFileContentsWithScheme("debug = false", "debug -> boolean")
+  ).toEqual({ debug: false });
+  // follows scheme(number)
+  expect(
+    parseSysctlFileContentsWithScheme("count = 452", "count -> number")
+  ).toEqual({ count: 452 });
+
+  // not following scheme(string)
+  expect(
+    parseSysctlFileContentsWithScheme(
+      "endpoint = localhost:3000",
+      "endpoint -> number"
+    )
+  ).toEqual({});
+  // not following scheme(boolean)
+  expect(
+    parseSysctlFileContentsWithScheme("debug = false", "debug -> string")
+  ).toEqual({});
+  // not following scheme(number)
+  expect(
+    parseSysctlFileContentsWithScheme("count = 452", "count -> boolean")
+  ).toEqual({});
+});
+test("dummy data will be parsed collectly with scheme", async () => {
+  const dummyData = await fs.readFile(dummyDataPath, "utf8");
+  const dummyScheme = await fs.readFile(dummySchemePath, "utf8");
+
+  expect(parseFileContents(dummyData, dummyScheme)).toEqual({
+    endpoint: "localhost:3000",
+    debug: true,
+    log: { conf: { file: "/var/log/config" } },
     count: 452,
   });
 });

--- a/src/utils/handleLine.js
+++ b/src/utils/handleLine.js
@@ -4,15 +4,20 @@ const isComment = (line) => {
   return false;
 };
 
-// single line should have single equeal.
-const hasLineOnlySingleEqual = (line) => {
-  const equalCharactersInLine = (line.match(new RegExp("=", "g")) || []).length;
+// single line should have single separator.
+const hasLineOnlySingleSeparator = (line, separator) => {
+  const equalCharactersInLine = (line.match(new RegExp(separator, "g")) || [])
+    .length;
   return equalCharactersInLine === 1;
 };
 
-const isValidLine = (line) => {
+const isValidLine = (line, separator) => {
   if (!line) return false;
-  return hasLineOnlySingleEqual(line) && !isComment(line);
+  return hasLineOnlySingleSeparator(line, separator) && !isComment(line);
 };
 
-module.exports = { isComment, hasLineOnlySingleEqual, isValidLine };
+module.exports = {
+  isComment,
+  hasLineOnlySingleSeparator,
+  isValidLine,
+};

--- a/src/utils/handleLine.test.js
+++ b/src/utils/handleLine.test.js
@@ -1,6 +1,6 @@
 const {
   isComment,
-  hasLineOnlySingleEqual,
+  hasLineOnlySingleSeparator,
   isValidLine,
 } = require("./handleLine");
 
@@ -8,38 +8,46 @@ test("line that starts with '#' or ';' is comment line", () => {
   // contains '#' (not leading character)
   expect(isComment("debug# = false")).toBe(false);
   // contains ';' (not leading character)
-  expect(isComment("debug = ;true")).toBe(false);
+  expect(isComment("debug -> ;boolean")).toBe(false);
 
   // starts with '#'
   expect(isComment("# debug = true")).toBe(true);
   // starts with ';'
-  expect(isComment("; debug = false")).toBe(true);
+  expect(isComment("; debug -> boolean")).toBe(true);
 });
 
-test("line should have only single equal", () => {
+test("line should have only single separator", () => {
   // common example
-  expect(hasLineOnlySingleEqual("endpoint = localhost:3000")).toBe(true);
+  expect(hasLineOnlySingleSeparator("endpoint = localhost:3000", "=")).toBe(
+    true
+  );
+  expect(hasLineOnlySingleSeparator("key -> value", "->")).toBe(true);
 
-  // contains 2 equals
-  expect(isComment("debug == true")).toBe(false);
-  // contains 0 equals
-  expect(isComment("debug false value")).toBe(false);
+  // contains 2 separator
+  expect(hasLineOnlySingleSeparator("debug == true", "=")).toBe(false);
+  expect(hasLineOnlySingleSeparator("debug ->-> string", "->")).toBe(false);
+  // contains 0 separator
+  expect(hasLineOnlySingleSeparator("lolem ipsum", "=")).toBe(false);
+  expect(hasLineOnlySingleSeparator("lolem - ipsum>", "->")).toBe(false);
 });
 
 test("sample lines validation", () => {
   // common example
-  expect(isValidLine("endpoint = localhost:3000")).toBe(true);
+  expect(isValidLine("endpoint = localhost:3000", "=")).toBe(true);
+
   // includes white space
-  expect(isValidLine(" test = testVal ")).toBe(true);
+  expect(isValidLine(" test -> string ", "->")).toBe(true);
   // includs '.' or '/'
-  expect(isValidLine("log.file = /var/log/console.log")).toBe(true);
+  expect(isValidLine("log.file = /var/log/console.log", "=")).toBe(true);
 
   // described as a comment
-  expect(isValidLine("# test2 = test2_value")).toBe(false);
+  expect(isValidLine("# test2 = test2_value", "=")).toBe(false);
   // described as a comment
-  expect(isValidLine("; test3 = test3 value")).toBe(false);
-  // includes more than one '='
-  expect(isValidLine("debug == true")).toBe(false);
-  // not includes '='
-  expect(isValidLine("dasdasbjdnw:")).toBe(false);
+  expect(isValidLine("; test3 = test3 value", "->")).toBe(false);
+  // includes more than one separator
+  expect(isValidLine("debug == true", "=")).toBe(false);
+  expect(isValidLine("debug ->-> true", "->")).toBe(false);
+  // not includes separator
+  expect(isValidLine("dasdasbjdnw:", "=")).toBe(false);
+  expect(isValidLine("lolem - ipsum>", "->")).toBe(false);
 });


### PR DESCRIPTION
# 概要
スキーマファイルをユーザーが作成でき、スキーマに従っていない場合にはロードしないようにする。

# 懸念点
* 現在対応している型は `[number. string, boolean, undefined]`の4つ
* 型の判定は`typeof`関数の返り値で判定しているので、今後プリミティブ型以外の型を定義したい場合は修正が必要になる。
